### PR TITLE
bind context of lockWatcher unlockWatcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,11 +93,11 @@ export const Watch = (Component) => class WatchedComponent extends React.Compone
 		this.watcher.destroy()
 	}
 
-	lockWatcher () {
+	lockWatcher = () => {
 		this.watcher.lock();
 	}
 
-	unlockWatcher () {
+	unlockWatcher = () => {
 		this.watcher.unlock();
 	}
 


### PR DESCRIPTION
Bind context of lockWatcher unlockWatcher to WatchedComponent.
Because `this.props.lockWatcher` raises `Uncaught TypeError: Cannot read property 'lock' of undefined`.